### PR TITLE
a little typo fixed in the example

### DIFF
--- a/types & grammar/apA.md
+++ b/types & grammar/apA.md
@@ -369,10 +369,10 @@ for (var i=1; i < 100000; i++) {
 }
 
 addAll( 2, 4, 6 );				// 12
-addAll.apply( null, nums );		// should be: 499950000
+addAll.apply( null, nums );		// should be: 4999950000
 ```
 
-In some JS engines, you'll get the correct `499950000` answer, but in others (like Safari 6.x), you'll get the error: "RangeError: Maximum call stack size exceeded."
+In some JS engines, you'll get the correct `4999950000` answer, but in others (like Safari 6.x), you'll get the error: "RangeError: Maximum call stack size exceeded."
 
 Examples of other limits known to exist:
 


### PR DESCRIPTION
> In some JS engines, you'll get the correct 499950000 answer, but in others (like Safari 6.x), you'll get the error: "RangeError: Maximum call stack size exceeded."

There should be 4999950000 (a 9 is missed – arithmetic progression from 1 to 99999 with step of 1) in the explanation and in the comment of the snippet above.
